### PR TITLE
Fix type for csrandom_range and use xlocale.h …

### DIFF
--- a/usual/crypto/csrandom.c
+++ b/usual/crypto/csrandom.c
@@ -40,7 +40,7 @@ void csrandom_bytes(void *buf, size_t nbytes)
 	arc4random_buf(buf, nbytes);
 }
 
-uint32_t csrandom_range(upper_bound)
+uint32_t csrandom_range(uint32_t upper_bound)
 {
 	return arc4random_uniform(upper_bound);
 }

--- a/usual/string.c
+++ b/usual/string.c
@@ -24,7 +24,7 @@
 #include <usual/bytemap.h>
 
 #include <errno.h>
-#include <locale.h>
+#include <xlocale.h>
 #ifdef HAVE_LANGINFO_H
 #include <langinfo.h>
 #endif


### PR DESCRIPTION
…instead of locale.h for newlocale(3)

Was trying to compile pgbouncer, and found your library (which it depends on) had two problems that made it not compile for me on my Mac:

There was a missig type in csrandom_range definition (but the declaration was fine)
You use locale.h to pull in newlocale() in string.h, but the more portable way to do that is to include xlocale.h.

Hope you can include these.
