### PR TITLE
Unbreak csrandom_range() on OpenBSD

### DIFF
--- a/usual/crypto/csrandom.c
+++ b/usual/crypto/csrandom.c
@@ -40,7 +40,7 @@ void csrandom_bytes(void *buf, size_t nbytes)
 	arc4random_buf(buf, nbytes);
 }
 
-uint32_t csrandom_range(upper_bound)
+uint32_t csrandom_range(uint32_t upper_bound)
 {
 	return arc4random_uniform(upper_bound);
 }


### PR DESCRIPTION
Tripped over this while building pgbouncer on OpenBSD 5.7

lib/usual/crypto/csrandom.c: In function 'csrandom_range':
lib/usual/crypto/csrandom.c:44: warning: old-style function definition
lib/usual/crypto/csrandom.c:44: warning: type of 'upper_bound' defaults to 'int'
lib/usual/crypto/csrandom.c:44: error: argument 'upper_bound' doesn't match prototype
lib/usual/crypto/csrandom.h:38: error: prototype declaration
/home/eradman/git/pgbouncer/lib/mk/antimake.mk:1222: recipe for target
'.objs/pgbouncer/lib/usual/crypto/csrandom.o' failed
gmake: *** [.objs/pgbouncer/lib/usual/crypto/csrandom.o] Error 1