### PR TITLE
Include stdarg.h to unbreak build on OpenBSD

### DIFF
--- a/usual/cxalloc.h
+++ b/usual/cxalloc.h
@@ -42,6 +42,7 @@
 #ifndef _USUAL_CXALLOC_H_
 #define _USUAL_CXALLOC_H_
 
+#include <stdarg.h>
 #include <usual/base.h>
 
 /**


### PR DESCRIPTION
Avoids this build error:

In file included from lib/usual/cbtree.h:24,
                 from lib/usual/cbtree.c:26:
lib/usual/cxalloc.h:133: error: expected declaration specifiers or '...' before 'va_list'
lib/usual/cxalloc.h:139: error: expected declaration specifiers or '...' before 'va_list'
/home/eradman/git/pgbouncer/lib/mk/antimake.mk:1222: recipe for target '.objs/pgbouncer/lib/usual/cbtree.o' failed
gmake: *** [.objs/pgbouncer/lib/usual/cbtree.o] Error 1

Also tested on Linux (CentOS 6.6)