### PR TITLE
build problems on solaris 10

### DIFF
--- a/m4/usual.m4
+++ b/m4/usual.m4
@@ -210,7 +210,7 @@ dnl
 AC_DEFUN([AC_USUAL_FUNCTION_CHECK], [
 ### Functions provided if missing
 dnl AC_CHECK_FUNCS(basename dirname) # unstable, provide always
-AC_CHECK_FUNCS(strlcpy strlcat strsep getpeereid sigaction sigqueue)
+AC_CHECK_FUNCS(strlcpy strlcat strnlen strsep getpeereid sigaction sigqueue)
 AC_CHECK_FUNCS(memmem memrchr mempcpy)
 AC_CHECK_FUNCS(inet_ntop inet_pton poll getline regcomp)
 AC_CHECK_FUNCS(err errx warn warnx getprogname setprogname)

--- a/test/test_string.c
+++ b/test/test_string.c
@@ -72,6 +72,26 @@ static void test_strlcat(void *ptr)
 end:;
 }
 
+
+/*
+ * strnlen()
+ */
+static void test_strnlen(void *p)
+{
+	tt_assert(strnlen("foobar", 0) == 0);
+	tt_assert(strnlen("foobar", 1) == 1);
+	tt_assert(strnlen("foobar", 2) == 2);
+	tt_assert(strnlen("foobar", 3) == 3);
+	tt_assert(strnlen("foobar", 4) == 4);
+	tt_assert(strnlen("foobar", 5) == 5);
+	tt_assert(strnlen("foobar", 6) == 6);
+	tt_assert(strnlen("foobar", 7) == 6);
+	tt_assert(strnlen("foobar", 8) == 6);
+	tt_assert(strnlen("foobar", 9) == 6);
+end:;
+}
+
+
 /*
  * strerror_r()
  */
@@ -607,6 +627,7 @@ end:;
 struct testcase_t string_tests[] = {
 	{ "strlcpy", test_strlcpy },
 	{ "strlcat", test_strlcat },
+	{ "strnlen", test_strnlen },
 	{ "strerror_r", test_strerror_r },
 	{ "memrchr", test_memrchr },
 	{ "memmem", test_memmem },

--- a/usual/fnmatch.h
+++ b/usual/fnmatch.h
@@ -26,9 +26,10 @@
 
 #include <usual/base.h>
 
-#ifdef HAVE_FNMATCH_H
+#if defined(HAVE_FNMATCH_H) && defined(FNM_CASEFOLD)
 #include <fnmatch.h>
 #else
+	/* fnmatch missing or incomplete */
 #define NEED_USUAL_FNMATCH
 #endif
 

--- a/usual/string.c
+++ b/usual/string.c
@@ -668,3 +668,12 @@ int vasprintf(char **dst_p, const char *fmt, va_list ap)
 
 #endif
 
+#ifndef HAVE_STRNLEN
+
+size_t strnlen(const char *string, size_t maxlen)
+{ 
+	const char *end = memchr(string, '\0', maxlen); 
+	return end ? (size_t)(end - string) : maxlen;
+}
+
+#endif

--- a/usual/string.h
+++ b/usual/string.h
@@ -54,6 +54,12 @@ const char *strlist_pop(struct StrList *slist);
 /** Parse comma-separated elements from string and launch callback for each of them. */
 bool parse_word_list(const char *s, str_cb cb_func, void *cb_arg);
 
+#ifndef HAVE_STRNLEN
+#define strnlen(a,b) usual_strnlen(a,b)
+/** Compat: determine the length of a fixed-size string */
+size_t strnlen(const char *string, size_t maxlen);
+#endif
+
 #ifndef HAVE_STRLCPY
 #define strlcpy(a,b,c) usual_strlcpy(a,b,c)
 /** Compat: Safely copy string to fixed-length buffer.  */

--- a/usual/talloc.c
+++ b/usual/talloc.c
@@ -21,6 +21,9 @@
 #include <usual/cxextra.h>
 #include <usual/list.h>
 #include <usual/bits.h>
+#ifndef HAVE_STRNLEN
+#include <usual/string.h>	/* needed for compat strnlen prototype  */
+#endif
 
 #include <string.h>
 

--- a/usual/time.c
+++ b/usual/time.c
@@ -179,6 +179,9 @@ int getrusage(int who, struct rusage *dst)
 
 #endif /* !HAVE_GETRUSAGE */
 
+
+#endif /* WIN32 */
+
 #ifndef HAVE_TIMEGM
 
 time_t timegm(struct tm *tm)
@@ -215,5 +218,3 @@ time_t timegm(struct tm *tm)
 }
 
 #endif /* HAVE_TIMEGM */
-
-#endif /* WIN32 */

--- a/usual/time.h
+++ b/usual/time.h
@@ -75,13 +75,6 @@ struct tm *localtime_r(const time_t *tp, struct tm *buf);
 
 #endif
 
-#ifndef HAVE_TIMEGM
-#define timegm(tm) usual_timegm(tm)
-
-/** Compat: timegm() */
-time_t timegm(struct tm *tm);
-
-#endif
 
 #ifndef HAVE_USLEEP
 #define usleep(x) usual_usleep(x)
@@ -106,6 +99,14 @@ struct rusage {
 int getrusage(int who, struct rusage *dst);
 
 #endif
+
+#endif
+
+#ifndef HAVE_TIMEGM
+#define timegm(tm) usual_timegm(tm)
+
+/** Compat: timegm() */
+time_t timegm(struct tm *tm);
 
 #endif
 

--- a/usual/tls/tls_compat.h
+++ b/usual/tls/tls_compat.h
@@ -9,6 +9,10 @@
 #include <usual/string.h>
 #include <usual/socket.h>
 
+#ifndef HAVE_TIMEGM
+#include <usual/time.h>	/* needed for compat timegm() */
+#endif
+
 #include <openssl/ssl.h>
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)

--- a/usual/tls/tls_conninfo.c
+++ b/usual/tls/tls_conninfo.c
@@ -17,6 +17,9 @@
  */
 
 #include "tls_compat.h"
+#ifndef HAVE_TIMEGM
+#include <usual/time.h>	/* needed for compat timegm() */
+#endif
 
 #ifdef USUAL_LIBSSL_FOR_TLS
 


### PR DESCRIPTION
solaris 10 build failed with unresolved symbols `strnlen` and `timegm`.